### PR TITLE
Adjust script call order and add missing role name prefix

### DIFF
--- a/src/db/addCourseMgmt.sql
+++ b/src/db/addCourseMgmt.sql
@@ -76,9 +76,9 @@ ALTER FUNCTION searchCourseTitles(title VARCHAR(100)) OWNER TO CURRENT_USER;
 
 REVOKE ALL ON FUNCTION searchCourseTitles(title VARCHAR(100)) FROM PUBLIC;
 
-GRANT EXECUTE ON FUNCTION searchCourseTitles(title VARCHAR(100)) TO GB_Webapp,
-alpha_GB_Instructor, alpha_GB_Student, alpha_GB_Registrar, alpha_GB_RegistrarAdmin, alpha_GB_Admissions,
-alpha_GB_DBAdmin;
+GRANT EXECUTE ON FUNCTION searchCourseTitles(title VARCHAR(100)) TO alpha_GB_Webapp,
+alpha_GB_Instructor, alpha_GB_Student, alpha_GB_Registrar, alpha_GB_RegistrarAdmin, 
+alpha_GB_Admissions, alpha_GB_DBAdmin;
 
 
 --Adds a course to the Course table. Name represents the abbreviated name of the
@@ -133,8 +133,8 @@ REVOKE ALL ON FUNCTION getCourseDefaultTitle(courseNumber VARCHAR(8))
 FROM PUBLIC;
 
 GRANT EXECUTE ON FUNCTION getCourseDefaultTitle(courseNumber VARCHAR(8)) TO
-GB_Webapp, alpha_GB_Instructor, alpha_GB_Student, alpha_GB_Registrar, alpha_GB_RegistrarAdmin,
-alpha_GB_Admissions, alpha_GB_DBAdmin;
+alpha_GB_Webapp, alpha_GB_Instructor, alpha_GB_Student, alpha_GB_Registrar, 
+alpha_GB_RegistrarAdmin, alpha_GB_Admissions, alpha_GB_DBAdmin;
 
 
 COMMIT;

--- a/src/db/addSectionMgmt.sql
+++ b/src/db/addSectionMgmt.sql
@@ -186,7 +186,7 @@ $$ LANGUAGE sql
   sectionNumber VARCHAR(3)) FROM PUBLIC;
 
   GRANT EXECUTE ON FUNCTION getSectionID(term INT, courseNumber VARCHAR(8),
-  sectionNumber VARCHAR(3)) TO GB_Webapp, alpha_GB_Instructor, alpha_GB_Student,
+  sectionNumber VARCHAR(3)) TO alpha_GB_Webapp, alpha_GB_Instructor, alpha_GB_Student,
   alpha_GB_Registrar, alpha_GB_RegistrarAdmin, alpha_GB_Admissions, alpha_GB_DBAdmin;
 
 
@@ -210,9 +210,9 @@ $$ LANGUAGE sql
 
   REVOKE ALL ON FUNCTION getSectionID(term INT, CRN VARCHAR(5)) FROM PUBLIC;
 
-  GRANT EXECUTE ON FUNCTION getSectionID(term INT, CRN VARCHAR(5)) TO GB_Webapp,
-  alpha_GB_Instructor, alpha_GB_Student, alpha_GB_Registrar, alpha_GB_RegistrarAdmin, alpha_GB_Admissions,
-  alpha_GB_DBAdmin;
+  GRANT EXECUTE ON FUNCTION getSectionID(term INT, CRN VARCHAR(5)) TO alpha_GB_Webapp,
+  alpha_GB_Instructor, alpha_GB_Student, alpha_GB_Registrar, alpha_GB_RegistrarAdmin, 
+  alpha_GB_Admissions, alpha_GB_DBAdmin;
 
 
   --Returns a table describing the section, which is populated with rows in
@@ -244,8 +244,9 @@ $$ LANGUAGE sql
 
   REVOKE ALL ON FUNCTION getSection(sectionID INT) FROM PUBLIC;
 
-  GRANT EXECUTE ON FUNCTION getSection(sectionID INT) TO GB_Webapp, alpha_GB_Instructor,
-  alpha_GB_Student, alpha_GB_Registrar, alpha_GB_RegistrarAdmin, alpha_GB_Admissions, alpha_GB_DBAdmin;
+  GRANT EXECUTE ON FUNCTION getSection(sectionID INT) TO alpha_GB_Webapp, 
+  alpha_GB_Instructor, alpha_GB_Student, alpha_GB_Registrar, 
+  alpha_GB_RegistrarAdmin, alpha_GB_Admissions, alpha_GB_DBAdmin;
 
 
   --Generates a list of class dates within a specified range. Uses char codes for
@@ -273,8 +274,8 @@ $$ LANGUAGE sql
   schedule VARCHAR(7)) FROM PUBLIC;
 
   GRANT EXECUTE ON FUNCTION getScheduleDates(startDate DATE, endDate DATE,
-  schedule VARCHAR(7)) TO GB_Webapp, alpha_GB_Instructor, alpha_GB_Student, alpha_GB_Registrar,
-  alpha_GB_RegistrarAdmin, alpha_GB_Admissions, alpha_GB_DBAdmin;
+  schedule VARCHAR(7)) TO alpha_GB_Webapp, alpha_GB_Instructor, alpha_GB_Student, 
+  alpha_GB_Registrar, alpha_GB_RegistrarAdmin, alpha_GB_Admissions, alpha_GB_DBAdmin;
 
 
   --Returns a table of rows from the section table where the title argument
@@ -307,8 +308,8 @@ $$ LANGUAGE sql
   FROM PUBLIC;
 
   GRANT EXECUTE ON FUNCTION searchSectionTitles(termID INT, title VARCHAR(100))
-  TO GB_Webapp, alpha_GB_Instructor, alpha_GB_Student, alpha_GB_Registrar, alpha_GB_RegistrarAdmin,
-  alpha_GB_Admissions, alpha_GB_DBAdmin;
+  TO alpha_GB_Webapp, alpha_GB_Instructor, alpha_GB_Student, alpha_GB_Registrar, 
+  alpha_GB_RegistrarAdmin, alpha_GB_Admissions, alpha_GB_DBAdmin;
 
 
 COMMIT;

--- a/src/db/addStudentMgmt.sql
+++ b/src/db/addStudentMgmt.sql
@@ -43,8 +43,9 @@ ALTER FUNCTION getStudentYears(studentID INT) OWNER TO CURRENT_USER;
 
 REVOKE ALL ON FUNCTION getStudentYears(studentID INT) FROM PUBLIC;
 
-GRANT EXECUTE ON FUNCTION getStudentYears(studentID INT) TO GB_Webapp,
-alpha_GB_Instructor, alpha_GB_Registrar, alpha_GB_RegistrarAdmin, alpha_GB_Admissions, alpha_GB_DBAdmin;
+GRANT EXECUTE ON FUNCTION getStudentYears(studentID INT) TO alpha_GB_Webapp,
+alpha_GB_Instructor, alpha_GB_Registrar, alpha_GB_RegistrarAdmin, alpha_GB_Admissions, 
+alpha_GB_DBAdmin;
 
 
 --Returns a table listing the years in which the student specified by
@@ -100,8 +101,8 @@ REVOKE ALL ON FUNCTION getStudentSeasons(studentID INT, year NUMERIC(4,0))
 FROM PUBLIC;
 
 GRANT EXECUTE ON FUNCTION getStudentSeasons(studentID INT, year NUMERIC(4,0))
-TO GB_Webapp, alpha_GB_Instructor, alpha_GB_Registrar, alpha_GB_RegistrarAdmin, alpha_GB_Admissions,
-alpha_GB_DBAdmin;
+TO alpha_GB_Webapp, alpha_GB_Instructor, alpha_GB_Registrar, alpha_GB_RegistrarAdmin,
+alpha_GB_Admissions, alpha_GB_DBAdmin;
 
 
 --Returns a table listing the seasons in which the student specified by
@@ -253,8 +254,8 @@ REVOKE ALL ON FUNCTION searchStudent(fname VARCHAR(50), mName VARCHAR(50),
 lName VARCHAR(50)) FROM PUBLIC;
 
 GRANT EXECUTE ON FUNCTION searchStudent(fname VARCHAR(50), mName VARCHAR(50),
-lName VARCHAR(50)) TO GB_Webapp, alpha_GB_Instructor, alpha_GB_Registrar, alpha_GB_RegistrarAdmin,
-alpha_GB_Admissions, alpha_GB_DBAdmin;
+lName VARCHAR(50)) TO alpha_GB_Webapp, alpha_GB_Instructor, alpha_GB_Registrar, 
+alpha_GB_RegistrarAdmin, alpha_GB_Admissions, alpha_GB_DBAdmin;
 
 
 --Returns the ID for the row in the Student table where the row's schoolIssuedID
@@ -299,8 +300,8 @@ REVOKE ALL ON FUNCTION getStudentIDByIssuedID(schoolIssuedID VARCHAR(50))
 FROM PUBLIC;
 
 GRANT EXECUTE ON FUNCTION getStudentIDByIssuedID(schoolIssuedID VARCHAR(50))
-TO GB_Webapp, alpha_GB_Instructor, alpha_GB_Registrar, alpha_GB_RegistrarAdmin, alpha_GB_Admissions,
-alpha_GB_DBAdmin;
+TO alpha_GB_Webapp, alpha_GB_Instructor, alpha_GB_Registrar, alpha_GB_RegistrarAdmin, 
+alpha_GB_Admissions, alpha_GB_DBAdmin;
 
 
 --Returns the ID for the row in the Student table where the row's schoolIssuedID
@@ -322,8 +323,9 @@ ALTER FUNCTION getStudentIDbyEmail(email VARCHAR(319)) OWNER TO CURRENT_USER;
 
 REVOKE ALL ON FUNCTION getStudentIDbyEmail(email VARCHAR(319)) FROM PUBLIC;
 
-GRANT EXECUTE ON FUNCTION getStudentIDbyEmail(email VARCHAR(319)) TO GB_Webapp,
-alpha_GB_Instructor, alpha_GB_Registrar, alpha_GB_RegistrarAdmin, alpha_GB_Admissions, alpha_GB_DBAdmin;
+GRANT EXECUTE ON FUNCTION getStudentIDbyEmail(email VARCHAR(319)) 
+TO alpha_GB_Webapp, alpha_GB_Instructor, alpha_GB_Registrar, alpha_GB_RegistrarAdmin, 
+alpha_GB_Admissions, alpha_GB_DBAdmin;
 
 
 --Changes midtermGradeAwarded in a row of the Enrollee table where the row's

--- a/src/db/addTermMgmt.sql
+++ b/src/db/addTermMgmt.sql
@@ -80,8 +80,8 @@ OWNER TO CURRENT_USER;
 REVOKE ALL ON FUNCTION getTermID(year NUMERIC(4,0), season CHAR(1)) FROM PUBLIC;
 
 GRANT EXECUTE ON FUNCTION getTermID(year NUMERIC(4,0), season CHAR(1))
-TO GB_Webapp, alpha_GB_Instructor, alpha_GB_Student, alpha_GB_Registrar, alpha_GB_RegistrarAdmin,
-alpha_GB_Admissions, alpha_GB_DBAdmin;
+TO alpha_GB_Webapp, alpha_GB_Instructor, alpha_GB_Student, alpha_GB_Registrar, 
+alpha_GB_RegistrarAdmin, alpha_GB_Admissions, alpha_GB_DBAdmin;
 
 
 --Returns the start date of a row from the Term table which matches the given
@@ -103,8 +103,9 @@ ALTER FUNCTION getTermStart(termID INT) OWNER TO CURRENT_USER;
 
 REVOKE ALL ON FUNCTION getTermStart(termID INT) FROM PUBLIC;
 
-GRANT EXECUTE ON FUNCTION getTermStart(termID INT) TO GB_Webapp, alpha_GB_Instructor,
-alpha_GB_Student, alpha_GB_Registrar, alpha_GB_RegistrarAdmin, alpha_GB_Admissions, alpha_GB_DBAdmin;
+GRANT EXECUTE ON FUNCTION getTermStart(termID INT) TO alpha_GB_Webapp, 
+alpha_GB_Instructor, alpha_GB_Student, alpha_GB_Registrar, alpha_GB_RegistrarAdmin, 
+alpha_GB_Admissions, alpha_GB_DBAdmin;
 
 
 --Returns the end date of a row from the Term table which matches the given
@@ -126,8 +127,9 @@ ALTER FUNCTION getTermEnd(termID INT) OWNER TO CURRENT_USER;
 
 REVOKE ALL ON FUNCTION getTermEnd(termID INT) FROM PUBLIC;
 
-GRANT EXECUTE ON FUNCTION getTermEnd(termID INT) TO GB_Webapp, alpha_GB_Instructor,
-alpha_GB_Student, alpha_GB_Registrar, alpha_GB_RegistrarAdmin, alpha_GB_Admissions, alpha_GB_DBAdmin;
+GRANT EXECUTE ON FUNCTION getTermEnd(termID INT) TO alpha_GB_Webapp, 
+alpha_GB_Instructor, alpha_GB_Student, alpha_GB_Registrar, alpha_GB_RegistrarAdmin, 
+alpha_GB_Admissions, alpha_GB_DBAdmin;
 
 
 --Returns rows from the SignificantDate table which have a matching TermID.
@@ -154,9 +156,9 @@ ALTER FUNCTION getSignificantDates(termID INT) OWNER TO CURRENT_USER;
 
 REVOKE ALL ON FUNCTION getSignificantDates(termID INT) FROM PUBLIC;
 
-GRANT EXECUTE ON FUNCTION getSignificantDates(termID INT) TO GB_Webapp,
-alpha_GB_Instructor, alpha_GB_Student, alpha_GB_Registrar, alpha_GB_RegistrarAdmin, alpha_GB_Admissions,
-alpha_GB_DBAdmin;
+GRANT EXECUTE ON FUNCTION getSignificantDates(termID INT) TO alpha_GB_Webapp,
+alpha_GB_Instructor, alpha_GB_Student, alpha_GB_Registrar, alpha_GB_RegistrarAdmin, 
+alpha_GB_Admissions, alpha_GB_DBAdmin;
 
 
 --Returns the total count of courses which occur in a given term. Returns a
@@ -180,9 +182,9 @@ ALTER FUNCTION getTermCourseCount(termID INT) OWNER TO CURRENT_USER;
 
 REVOKE ALL ON FUNCTION getTermCourseCount(termID INT) FROM PUBLIC;
 
-GRANT EXECUTE ON FUNCTION getTermCourseCount(termID INT) TO GB_Webapp,
-alpha_GB_Instructor, alpha_GB_Student, alpha_GB_Registrar, alpha_GB_RegistrarAdmin, alpha_GB_Admissions,
-alpha_GB_DBAdmin;
+GRANT EXECUTE ON FUNCTION getTermCourseCount(termID INT) TO alpha_GB_Webapp,
+alpha_GB_Instructor, alpha_GB_Student, alpha_GB_Registrar, alpha_GB_RegistrarAdmin, 
+alpha_GB_Admissions, alpha_GB_DBAdmin;
 
 
 --Returns the total count of sections which occur during a given term. Counts
@@ -206,9 +208,9 @@ ALTER FUNCTION getTermSectionCount(termID INT) OWNER TO CURRENT_USER;
 
 REVOKE ALL ON FUNCTION getTermSectionCount(termID INT) FROM PUBLIC;
 
-GRANT EXECUTE ON FUNCTION getTermSectionCount(termID INT) TO GB_Webapp,
-alpha_GB_Instructor, alpha_GB_Student, alpha_GB_Registrar, alpha_GB_RegistrarAdmin, alpha_GB_Admissions,
-alpha_GB_DBAdmin;
+GRANT EXECUTE ON FUNCTION getTermSectionCount(termID INT) TO alpha_GB_Webapp,
+alpha_GB_Instructor, alpha_GB_Student, alpha_GB_Registrar, alpha_GB_RegistrarAdmin, 
+alpha_GB_Admissions, alpha_GB_DBAdmin;
 
 
 --Returns the total count of instructors teaching during a given term. Returns 0
@@ -231,9 +233,9 @@ ALTER FUNCTION getTermInstructorCount(termID INT) OWNER TO CURRENT_USER;
 
 REVOKE ALL ON FUNCTION getTermInstructorCount(termID INT) FROM PUBLIC;
 
-GRANT EXECUTE ON FUNCTION getTermInstructorCount(termID INT) TO GB_Webapp,
-alpha_GB_Instructor, alpha_GB_Student, alpha_GB_Registrar, alpha_GB_RegistrarAdmin, alpha_GB_Admissions,
-alpha_GB_DBAdmin;
+GRANT EXECUTE ON FUNCTION getTermInstructorCount(termID INT) TO alpha_GB_Webapp,
+alpha_GB_Instructor, alpha_GB_Student, alpha_GB_Registrar, alpha_GB_RegistrarAdmin, 
+alpha_GB_Admissions, alpha_GB_DBAdmin;
 
 
 --Returns a table matching rows in the Section table, which has a schema similar
@@ -267,9 +269,9 @@ ALTER FUNCTION getTermSectionsReport(termID INT) OWNER TO CURRENT_USER;
 
 REVOKE ALL ON FUNCTION getTermSectionsReport(termID INT) FROM PUBLIC;
 
-GRANT EXECUTE ON FUNCTION getTermSectionsReport(termID INT) TO GB_Webapp,
-alpha_GB_Instructor, alpha_GB_Student, alpha_GB_Registrar, alpha_GB_RegistrarAdmin, alpha_GB_Admissions,
-alpha_GB_DBAdmin;
+GRANT EXECUTE ON FUNCTION getTermSectionsReport(termID INT) TO alpha_GB_Webapp,
+alpha_GB_Instructor, alpha_GB_Student, alpha_GB_Registrar, alpha_GB_RegistrarAdmin, 
+alpha_GB_Admissions, alpha_GB_DBAdmin;
 
 
 --Returns a table matching the schema of a Section table, containing rows which
@@ -305,9 +307,9 @@ ALTER FUNCTION getTermSections(termID INT) OWNER TO CURRENT_USER;
 
 REVOKE ALL ON FUNCTION getTermSections(termID INT) FROM PUBLIC;
 
-GRANT EXECUTE ON FUNCTION getTermSections(termID INT) TO GB_Webapp,
-alpha_GB_Instructor, alpha_GB_Student, alpha_GB_Registrar, alpha_GB_RegistrarAdmin, alpha_GB_Admissions,
-alpha_GB_DBAdmin;
+GRANT EXECUTE ON FUNCTION getTermSections(termID INT) TO alpha_GB_Webapp,
+alpha_GB_Instructor, alpha_GB_Student, alpha_GB_Registrar, alpha_GB_RegistrarAdmin, 
+alpha_GB_Admissions, alpha_GB_DBAdmin;
 
 
 --Returns the total count of students which are taking a class in a given term.
@@ -330,9 +332,9 @@ ALTER FUNCTION getTermStudentCount(termID INT) OWNER TO CURRENT_USER;
 
 REVOKE ALL ON FUNCTION getTermStudentCount(termID INT) FROM PUBLIC;
 
-GRANT EXECUTE ON FUNCTION getTermStudentCount(termID INT) TO GB_Webapp,
-alpha_GB_Instructor, alpha_GB_Student, alpha_GB_Registrar, alpha_GB_RegistrarAdmin, alpha_GB_Admissions,
-alpha_GB_DBAdmin;
+GRANT EXECUTE ON FUNCTION getTermStudentCount(termID INT) TO alpha_GB_Webapp,
+alpha_GB_Instructor, alpha_GB_Student, alpha_GB_Registrar, alpha_GB_RegistrarAdmin, 
+alpha_GB_Admissions, alpha_GB_DBAdmin;
 
 
 --Returns a table of rows from the Course table. Without arguments, returns all
@@ -360,9 +362,9 @@ ALTER FUNCTION showCoursesByYear(year NUMERIC(4,0)) OWNER TO CURRENT_USER;
 
 REVOKE ALL ON FUNCTION showCoursesByYear(year NUMERIC(4,0)) FROM PUBLIC;
 
-GRANT EXECUTE ON FUNCTION showCoursesByYear(year NUMERIC(4,0)) TO GB_Webapp,
-alpha_GB_Instructor, alpha_GB_Student, alpha_GB_Registrar, alpha_GB_RegistrarAdmin, alpha_GB_Admissions,
-alpha_GB_DBAdmin;
+GRANT EXECUTE ON FUNCTION showCoursesByYear(year NUMERIC(4,0)) TO alpha_GB_Webapp,
+alpha_GB_Instructor, alpha_GB_Student, alpha_GB_Registrar, alpha_GB_RegistrarAdmin, 
+alpha_GB_Admissions, alpha_GB_DBAdmin;
 
 
 --Returns a table of rows from the Course table. Without arguments, returns all
@@ -390,9 +392,9 @@ ALTER FUNCTION showCoursesByTerm(termID INT) OWNER TO CURRENT_USER;
 
 REVOKE ALL ON FUNCTION showCoursesByTerm(termID INT) FROM PUBLIC;
 
-GRANT EXECUTE ON FUNCTION showCoursesByTerm(termID INT) TO GB_Webapp,
-alpha_GB_Instructor, alpha_GB_Student, alpha_GB_Registrar, alpha_GB_RegistrarAdmin, alpha_GB_Admissions,
-alpha_GB_DBAdmin;
+GRANT EXECUTE ON FUNCTION showCoursesByTerm(termID INT) TO alpha_GB_Webapp,
+alpha_GB_Instructor, alpha_GB_Student, alpha_GB_Registrar, alpha_GB_RegistrarAdmin, 
+alpha_GB_Admissions, alpha_GB_DBAdmin;
 
 
 COMMIT;

--- a/src/db/prepareDB.psql
+++ b/src/db/prepareDB.psql
@@ -32,9 +32,9 @@ SET client_min_messages TO WARNING;
 \i createTables.sql
 \i addReferenceData.sql
 \i addSeasonMgmt.sql
-\i addSectionMgmt.sql
-\i addAttendanceMgmt.sql
 \i addInstructorMgmt.sql
 \i addCourseMgmt.sql
 \i addStudentMgmt.sql
 \i addTermMgmt.sql
+\i addSectionMgmt.sql
+\i addAttendanceMgmt.sql

--- a/src/db/prepareServer.sql
+++ b/src/db/prepareServer.sql
@@ -112,7 +112,7 @@ BEGIN
    --create user alpha_GB_WebApp if necessary and make sure the user is a member of
    --Gradebook role
    -- a default password is assigned to the user: user/admin should change it
-   IF NOT pg_temp.existsRole('gb_webapp') THEN
+   IF NOT pg_temp.existsRole('alpha_gb_webapp') THEN
       CREATE USER alpha_GB_WebApp WITH PASSWORD 'dassl2017';
    END IF;
 


### PR DESCRIPTION
In addSectionMgmt.sql, getSection(INT) calls getInstructorName(INT), which is declared in addInstructorMgmt.sql.  Also fixed a missing 'alpha_' prefix.

When running setup scripts, this causes an error. Reordering the script calls to resolves this issue.