### PR TITLE
Add new tables defined in M4 (SignificantDate, Major, Student_Major)

### DIFF
--- a/src/db/dropTables.sql
+++ b/src/db/dropTables.sql
@@ -1,4 +1,11 @@
---createTables.sql - GradeBook
+--createTables.sql - Gradebook
+
+--Edited by Bruno DaSilva, Andrew Figueroa, and Jonathan Middleton (Team Alpha)
+-- in support of CS305 coursework at Western Connecticut State University.
+
+--Licensed to others under CC 4.0 BY-SA-NC
+
+--This work is a derivative of Gradebook, originally developed by:
 
 --Zaid Bhujwala, Zach Boylan, Steven Rollo, Sean Murthy
 --Data Science & Systems Lab (DASSL), Western Connecticut State University (WCSU)
@@ -24,11 +31,14 @@ SET LOCAL search_path TO 'alpha', 'pg_temp';
 DROP TABLE IF EXISTS Course CASCADE;
 DROP TABLE IF EXISTS Season CASCADE;
 DROP TABLE IF EXISTS Term CASCADE;
+DROP TABLE IF EXISTS SignificantDate CASCADE;
 DROP TABLE IF EXISTS Instructor CASCADE;
 DROP TABLE IF EXISTS Section CASCADE;
 DROP TABLE IF EXISTS Grade CASCADE;
 DROP TABLE IF EXISTS Section_GradeTier CASCADE;
 DROP TABLE IF EXISTS Student CASCADE;
+DROP TABLE IF EXISTS Major CASCADE;
+DROP TABLE IF EXISTS Student_Major CASCADE;
 DROP TABLE IF EXISTS Enrollee CASCADE;
 DROP TABLE IF EXISTS AttendanceStatus CASCADE;
 DROP TABLE IF EXISTS AttendanceRecord CASCADE;


### PR DESCRIPTION
The `createTables.sql` script that was in the repository was from the original DASSL version of Gradebook. New tables that were defined in M4 have been copied over and integrated into the new script structure.

The new tables were also added to `dropTables.sql`. (The drops are performed with `CASCADE` to match the existing statements in the script, but should ideally not use `CASCADE` and instead be dropped in the appropriate order.)

Closes #8