### PR TITLE
Implementation of /sectionschedule endpoint

### DIFF
--- a/src/db/addAttendanceMgmt.sql
+++ b/src/db/addAttendanceMgmt.sql
@@ -68,13 +68,13 @@ AS $$
    SELECT sd
    FROM EnumeratedDate
    WHERE CASE --test match to schedule by extracting the day-of-week for the date
-      WHEN EXTRACT(DOW FROM sd) = 0 THEN $3 LIKE '%N%'
-      WHEN EXTRACT(DOW FROM sd) = 1 THEN $3 LIKE '%M%'
-      WHEN EXTRACT(DOW FROM sd) = 2 THEN $3 LIKE '%T%'
-      WHEN EXTRACT(DOW FROM sd) = 3 THEN $3 LIKE '%W%'
-      WHEN EXTRACT(DOW FROM sd) = 4 THEN $3 LIKE '%R%'
-      WHEN EXTRACT(DOW FROM sd) = 5 THEN $3 LIKE '%F%'
-      WHEN EXTRACT(DOW FROM sd) = 6 THEN $3 LIKE '%S%'
+      WHEN EXTRACT(DOW FROM sd) = 0 THEN $3 ILIKE '%N%'
+      WHEN EXTRACT(DOW FROM sd) = 1 THEN $3 ILIKE '%M%'
+      WHEN EXTRACT(DOW FROM sd) = 2 THEN $3 ILIKE '%T%'
+      WHEN EXTRACT(DOW FROM sd) = 3 THEN $3 ILIKE '%W%'
+      WHEN EXTRACT(DOW FROM sd) = 4 THEN $3 ILIKE '%R%'
+      WHEN EXTRACT(DOW FROM sd) = 5 THEN $3 ILIKE '%F%'
+      WHEN EXTRACT(DOW FROM sd) = 6 THEN $3 ILIKE '%S%'
    END;
 $$ LANGUAGE sql
             IMMUTABLE
@@ -94,15 +94,14 @@ GRANT EXECUTE ON FUNCTION getScheduleDates(startDate DATE, endDate DATE,
    alpha_GB_Registrar, alpha_GB_RegistrarAdmin, alpha_GB_Admissions,
    alpha_GB_DBAdmin;
 
+
 --Returns a section schedule by providing a sectionID.  Does NOT consider
 -- off-days, holidays, etc.
-CREATE FUNCTION getScheduleDates(sectionID INT)
+CREATE OR REPLACE FUNCTION getScheduleDates(sectionID INT)
 RETURNS TABLE (ScheduleDate DATE) AS 
 $$
-
    SELECT getScheduleDates(S.startdate, S.enddate, S.schedule)
    FROM section S WHERE S.id = $1;
-
 $$ LANGUAGE sql
             IMMUTABLE
             RETURNS NULL ON NULL INPUT;

--- a/src/db/addAttendanceMgmt.sql
+++ b/src/db/addAttendanceMgmt.sql
@@ -94,6 +94,33 @@ GRANT EXECUTE ON FUNCTION getScheduleDates(startDate DATE, endDate DATE,
    alpha_GB_Registrar, alpha_GB_RegistrarAdmin, alpha_GB_Admissions,
    alpha_GB_DBAdmin;
 
+--Returns a section schedule by providing a sectionID.  Does NOT consider
+-- off-days, holidays, etc.
+CREATE FUNCTION getScheduleDates(sectionID INT)
+RETURNS TABLE (ScheduleDate DATE) AS 
+$$
+
+   SELECT getScheduleDates(S.startdate, S.enddate, S.schedule)
+   FROM section S WHERE S.id = $1;
+
+$$ LANGUAGE sql
+            IMMUTABLE
+            RETURNS NULL ON NULL INPUT;
+
+ALTER FUNCTION getScheduleDates(startDate DATE, endDate DATE,
+                                schedule VARCHAR(7))
+   OWNER TO alpha;
+
+REVOKE ALL ON FUNCTION getScheduleDates(startDate DATE, endDate DATE, 
+                                        schedule VARCHAR(7))
+   FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION getScheduleDates(startDate DATE, endDate DATE, 
+                                           schedule VARCHAR(7))
+   TO alpha_GB_Webapp, alpha_GB_Instructor, alpha_GB_Student,
+   alpha_GB_Registrar, alpha_GB_RegistrarAdmin, alpha_GB_Admissions,
+   alpha_GB_DBAdmin;
+
 
 --Function to get attendance for a section ID
 DROP FUNCTION IF EXISTS getAttendance(INT);

--- a/src/webapp/gradebookServer.js
+++ b/src/webapp/gradebookServer.js
@@ -300,11 +300,7 @@ app.get('/sectionschedule', function(request, response) {
 
    executeQuery(response, config, queryText, queryParams, function(result) {
       for(row in result.rows) {
-         closedDates.push(
-            {
-               "date": result.rows[row].date
-            }
-         );
+         closedDates.push( result.rows[row].date);
       }
    });
 
@@ -316,11 +312,7 @@ app.get('/sectionschedule', function(request, response) {
       for(row in result.rows) {
          if(!closedDates.includes(result.rows[row].date))
          {
-            classDates.push(
-               {
-                  "date": result.rows[row].date
-               }
-            );
+            classDates.push(result.rows[row].date);
          }
       }
       var jsonReturn = {

--- a/src/webapp/gradebookServer.js
+++ b/src/webapp/gradebookServer.js
@@ -308,7 +308,7 @@ app.get('/sectionschedule', function(request, response) {
       }
    });
 
-   queryText = 'SELECT getScheduleDates($1);';
+   queryText = 'SELECT scheduledate::VARCHAR AS date FROM getScheduleDates($1);';
    queryParams = [sectionID];
 
    executeQuery(response, config, queryText, queryParams, function(result) {

--- a/src/webapp/gradebookServer.js
+++ b/src/webapp/gradebookServer.js
@@ -294,7 +294,7 @@ app.get('/sectionschedule', function(request, response) {
 
    var sectionID = request.query.sectionID;
 
-   var queryText = 'SELECT date FROM significantDate WHERE classesheld = false;';
+   var queryText = 'SELECT date::VARCHAR FROM significantDate WHERE NOT classesheld;';
    var queryParams = [];
    var closedDates = [];
 


### PR DESCRIPTION
Implements /sectionschedule endpoint.  Gets an array of dates when the Uni is closed.  Then returns an array of dates for a given section.

Added DB function getScheduleDates() which returns a schedule given ONLY a section ID.

_Alternately..._

An additional DB function could return this in one query, using the new getScheduleDates(sectionID) function and comparing with the significantdate table.  Let me know what you guys think.