### PR TITLE
Make post-M6 fixes to DB scripts

### DIFF
--- a/src/db/addInstructorMgmt.sql
+++ b/src/db/addInstructorMgmt.sql
@@ -370,7 +370,7 @@ GRANT EXECUTE ON FUNCTION getInstructorSections(instructorID INT,
                                           courseNumber VARCHAR(8)
                                           )
    TO alpha_GB_Webapp, alpha_GB_Instructor, alpha_GB_Registrar, 
-      alpha_GB_RegistrarAdmin, alpha_GB_Admissions, alpha_GB_DBAdmin;
+   alpha_GB_RegistrarAdmin, alpha_GB_Admissions, alpha_GB_DBAdmin;
 
 --Returns the full name of an instructor given an instructor ID
 CREATE OR REPLACE FUNCTION getInstructorName(instructorID INT)
@@ -382,10 +382,10 @@ $$
     FROM Instructor
     WHERE id = $1;
 $$ LANGUAGE sql
-SECURITY DEFINER
-SET search_path FROM CURRENT;
-STABLE
-RETURNS NULL ON NULL INPUT;
+   SECURITY DEFINER
+   SET search_path FROM CURRENT
+   STABLE
+   RETURNS NULL ON NULL INPUT;
 
 ALTER FUNCTION getInstructorName(instructorID INT) OWNER TO CURRENT_USER;
 

--- a/src/db/addReferenceData.sql
+++ b/src/db/addReferenceData.sql
@@ -33,7 +33,8 @@ SET LOCAL search_path TO 'alpha', 'pg_temp';
 INSERT INTO Season("Order", Name, Code)
 VALUES
    ('0','Spring','S'),  ('1','Spring_Break','B'),  ('2','Summer','M'),
-   ('3','Fall','F'),    ('4','Intersession','I');
+   ('3','Fall','F'),    ('4','Intersession','I')
+ON CONFLICT DO NOTHING;
 
 
 
@@ -44,7 +45,8 @@ INSERT INTO Grade(Letter, GPA)
 VALUES
    ('A+', 4.333), ('A', 4),      ('A-', 3.667), ('B+', 3.333), ('B', 3),
    ('B-', 2.667), ('C+', 2.333), ('C', 2),      ('C-', 1.667), ('D+', 1.333),
-   ('D', 1),      ('D-', 0.667), ('F', 0),      ('W', 0),      ('SA', 0);
+   ('D', 1),      ('D-', 0.667), ('F', 0),      ('W', 0),      ('SA', 0)
+ON CONFLICT DO NOTHING;
 
 
 
@@ -55,7 +57,8 @@ INSERT INTO AttendanceStatus(Status, Description)
 VALUES
    ('P', 'Present'),           ('A', 'Absent'),   ('E', 'Explained'),
    ('S', 'Stopped Attending'), ('X', 'Excused'),  ('N', 'Not Registered'),
-   ('C', 'Cancelled'),         ('W', 'Withdrawn');
+   ('C', 'Cancelled'),         ('W', 'Withdrawn')
+ON CONFLICT DO NOTHING;
 
 
 COMMIT;

--- a/src/db/addSeasonMgmt.sql
+++ b/src/db/addSeasonMgmt.sql
@@ -116,8 +116,8 @@ CREATE OR REPLACE FUNCTION listSeasons()
                   Code CHAR(1)
                 ) AS
 $$
-   SELECT name, code
-   FROM season;
+   SELECT "Order", s.name, s.code
+   FROM season s;
 $$ LANGUAGE sql
    SECURITY DEFINER
    SET search_path FROM CURRENT

--- a/src/db/prepareDB.psql
+++ b/src/db/prepareDB.psql
@@ -29,6 +29,7 @@
 \set ON_ERROR_STOP on
 SET client_min_messages TO WARNING;
 --\i initializeDB.sql
+\i addHelpers.sql
 \i createTables.sql
 \i addReferenceData.sql
 \i addSeasonMgmt.sql

--- a/src/db/prepareServer.sql
+++ b/src/db/prepareServer.sql
@@ -34,19 +34,6 @@ START TRANSACTION;
 --Suppress messages below WARNING level for the duration of this script
 SET LOCAL client_min_messages TO WARNING;
 
---Make sure current user is superuser
-DO
-$$
-BEGIN
-   IF NOT EXISTS (SELECT * FROM pg_catalog.pg_roles
-                  WHERE rolname = current_user AND rolsuper = TRUE
-                 ) THEN
-      RAISE EXCEPTION 'Insufficient privileges: '
-                      'script must be run by a superuser';
-   END IF;
-END
-$$;
-
 
 --Create a temporary function to test if a role with the given name exists
 -- performs case-sensitive test for roleName;


### PR DESCRIPTION
The full project can now be installed in a database without errors.  All scripts are now fullly idempotent (no need to uninstall before re-installing).

Many syntax errors and formatting inconsistencies were addressed. Some logical errors were also fixed (instructor count is now accurate, cast term-related count scripts to correct data type).

The scripts are also now completely idempotent (no need to uninstall before reinstalling).