### PR TITLE
New section selection

### DIFF
--- a/src/db/addSectionMgmt.sql
+++ b/src/db/addSectionMgmt.sql
@@ -88,6 +88,7 @@ RETURNS TABLE
    Term INT,
    Course VARCHAR(8),
    SectionNumber VARCHAR(3),
+   Title VARCHAR(100),
    CRN VARCHAR(5),
    Schedule VARCHAR(7),
    Location VARCHAR(25),
@@ -100,9 +101,10 @@ RETURNS TABLE
 )
 AS
 $$
-   SELECT N.ID, N.Term, N.Course, N.SectionNumber, N.CRN, N.Schedule, N.Location,
-         COALESCE(N.StartDate, T.StartDate), COALESCE(N.EndDate, T.EndDate),
-         N.MidtermDate, N.Instructor1, N.Instructor2, N.Instructor3
+   SELECT N.ID, N.Term, N.Course, N.SectionNumber, N.Title, N.CRN, N.Schedule,
+         N.Location, COALESCE(N.StartDate, T.StartDate),
+         COALESCE(N.EndDate, T.EndDate), N.MidtermDate, N.Instructor1,
+         N.Instructor2, N.Instructor3
    FROM Section N JOIN Term T ON N.Term  = T.ID
    WHERE T.Year = $1
          AND T.Season = getSeasonOrder($2)
@@ -131,6 +133,7 @@ RETURNS TABLE
    Term INT,
    Course VARCHAR(8),
    SectionNumber VARCHAR(3),
+   Title VARCHAR(100),
    CRN VARCHAR(5),
    Schedule VARCHAR(7),
    Location VARCHAR(25),
@@ -143,7 +146,7 @@ RETURNS TABLE
 )
 AS
 $$
-   SELECT ID, Term, Course, SectionNumber, CRN, Schedule, Location,
+   SELECT ID, Term, Course, SectionNumber, Title, CRN, Schedule, Location,
          StartDate, EndDate,
          MidtermDate, Instructor1, Instructor2, Instructor3
    FROM getSection($1, $2::VARCHAR, $3, $4);
@@ -215,6 +218,7 @@ CREATE OR REPLACE FUNCTION getSection(sectionID INT)
    RETURNS TABLE(Term INT,
                  Course VARCHAR(8),
                  SectionNumber VARCHAR(3),
+                 Title VARCHAR(100),
                  CRN VARCHAR(5),
                  Schedule VARCHAR(7),
                  Location VARCHAR(25),
@@ -224,8 +228,8 @@ CREATE OR REPLACE FUNCTION getSection(sectionID INT)
                  Instructors VARCHAR(150)
                 ) AS
 $$
-   SELECT s.term, s.course, s.sectionnumber, s.crn, s.schedule, s.location,
-   s.startdate, s.enddate, s.midtermdate,
+   SELECT s.term, s.course, s.sectionnumber, s.title, s.crn, s.schedule,
+      s.location, s.startdate, s.enddate, s.midtermdate,
       COALESCE(getInstructorName(s.instructor1),'') ||
       COALESCE(', ' || getInstructorName(s.instructor2),'') ||
       COALESCE(', ' || getInstructorName(s.instructor3),'')

--- a/src/webapp/client/index.html
+++ b/src/webapp/client/index.html
@@ -129,36 +129,55 @@ Currently, only attendance information is served
 	</div>
 	
 	<div id="attendance">
+
+	<div id="sectionListing" class="section">
 	<div class="row">
-		<div class="input-field col s12 m6 l3">
+		<h4 class="col s6 m3 l3">Sections</h4>
+		<div class="input-field col s6 m3 l3">
 			<select id="yearSelect" disabled="true">
 				<option value="" disabled="true" selected="true">Choose year</option>
 			</select>
 			<label>Year</label>
 		</div>
-		<div class="input-field col s12 m6 l3">
+		<div class="input-field col s6 m3 l3">
 			<select id="seasonSelect" disabled="true">
 				<option value="" disabled="true" selected="true">Choose season</option>
 			</select>
 			<label>Season</label>
 		</div>
-		<div class="input-field col s12 m6 l3">
-			<select id="courseSelect" disabled="true">
-				<option value="" disabled="true" selected="true">Choose course</option>
-			</select>
-			<label>Course</label>
+	</div>
+	<table id="sectionListingTable" style="display: none" class="highlight">
+		<thead>
+			<tr>
+			  <th>Course</th>
+			  <th>Section</th>
+			  <th>Title</th>
+			  <th>Schedule</th>
+			  <th>Location</th>
+			  <th>Instructors</th>
+			</tr>
+		  </thead>
+		  <tbody id="sectionListBody"></tbody>
+	</table>
+	</div>
+
+	<div id="currentSelection" style="display: none">
+	<div class="row">
+		<div id="currentSection" class="col s9 m10 l11">
+			<!-- Intended to hold a short description of what is being displayed -->
 		</div>
-		<div class="input-field col s12 m6 l3">
-			<select id="sectionSelect" disabled="true">
-				<option value="" disabled="true" selected="true">Choose section</option>
-			</select>
-			<label>Section</label>
+		<div id="returnToSelection-wrapper" class="col s3 m2 l1">
+			<a id="btnReturnToSelect"
+			 class="btn-floating waves-effect waves-light teal lighten-2 tooltipped"
+			 data-position="bottom" data-delay="50" data-tooltip="Return to selection">
+				<i class="material-icons">list</i>
+			</a>
 		</div>
 	</div>
+	</div>
 	
-	<div class="divider"></div>
-	
-	<ul id="attnOptionsBox" class="collapsible" style="display: none" data-collapsible="expandable">
+	<div id="attnOptionsBox-wrapper" style="display: none">
+	<ul id="attnOptionsBox" class="collapsible" data-collapsible="expandable">
 	<li>
 		<div class="collapsible-header">
 			<i id="optionsArrow" class="material-icons">keyboard_arrow_down</i>Options
@@ -182,9 +201,10 @@ Currently, only attendance information is served
 		</div>
 	</li>
 	</ul>
+	</div>
 	
 	<br/>
-	<div id="attendanceData" class="col s12" style="overflow-x:auto">
+	<div id="attendanceData" class="col s12" style="overflow-x:auto; display:none;">
 		<!--Populated dynamically-->
 	</div>
 	

--- a/src/webapp/client/js/index.js
+++ b/src/webapp/client/js/index.js
@@ -284,28 +284,7 @@ function listCourses(connInfo, user, year, seasonorder) {
 					dataType: 'json',
 					data: urlParams,
 					success: function(result) {
-						//sort sections based on section number
-						result.sections.sort(function (a,b) {
-							return a.sectionnumber < b.sectionnumber;
-						});
-
-						//build table row for each section
-						var sections = '';
-						for (var j = 0; j < result.sections.length; j++) {
-							var sectionObjStr = JSON.stringify(result.sections[j]).replace(/&/g, '&amp;').replace(/"/g, '&quot;');
-							sections += '<tr onclick="popAttendance(dbInfo, \'' + sectionObjStr + '\')"';
-							sections += 	' onmouseover="" style="cursor: pointer;">';
-							sections += '<td>' + result.sections[j].sectioncourse + '</td>';
-							sections += '<td>' + result.sections[j].sectionnumber + '</td>';
-							sections += '<td>' + result.sections[j].sectiontitle + '</td>';
-							sections += '<td>' + result.sections[j].sectionschedule + '</td>';
-							sections += '<td>' + result.sections[j].sectionlocation + '</td>';
-							sections += '<td>' + result.sections[j].sectioninstructors + '</td>';
-							sections += '</tr>';
-						}
-
-						//append new section to section list
-						appendSectionList(sections);
+						addResultToSectionList(result)
 					},
 					error: function(result) {
 						showAlert('<p>Error while retrieving sections</p>');
@@ -320,6 +299,31 @@ function listCourses(connInfo, user, year, seasonorder) {
 		}
 	});
 };
+
+function addResultToSectionList(result) {
+	//sort sections based on section number
+	result.sections.sort(function (a,b) {
+		return a.sectionnumber < b.sectionnumber;
+	});
+
+	//build table row for each section
+	var sections = '';
+	for (var j = 0; j < result.sections.length; j++) {
+		var sectionObjStr = JSON.stringify(result.sections[j]).replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+		sections += '<tr onclick="popAttendance(dbInfo, \'' + sectionObjStr + '\')"';
+		sections += 	' onmouseover="" style="cursor: pointer;">';
+		sections += '<td>' + result.sections[j].sectioncourse + '</td>';
+		sections += '<td>' + result.sections[j].sectionnumber + '</td>';
+		sections += '<td>' + result.sections[j].sectiontitle + '</td>';
+		sections += '<td>' + result.sections[j].sectionschedule + '</td>';
+		sections += '<td>' + result.sections[j].sectionlocation + '</td>';
+		sections += '<td>' + result.sections[j].sectioninstructors + '</td>';
+		sections += '</tr>';
+	}
+
+	//append new section to section list
+	appendSectionList(sections);
+}
 
 function appendSectionList(htmlText) {
 	var currList = $('#sectionListBody').html();

--- a/src/webapp/client/js/index.js
+++ b/src/webapp/client/js/index.js
@@ -27,6 +27,10 @@ var dbInfo = {
 };
 var instInfo = { "fname":null, "mname":null, "lname": null, "dept":null };
 
+var displayedSection = {"id":null, "sectioncourse":null, "sectionnumber":null,
+	"sectiontitle":null, "sectionschedule":null, "sectionlocation":null,
+	"sectioninstructors":null};
+
 /* 
 Each instance of connInfo as a parameter in a function definition refers to an 
  object with the following keys, which are used as part of the REST API calls to
@@ -98,31 +102,28 @@ $(document).ready(function() {
 	$('#seasonSelect').change(function() {
 		var year = $('#yearSelect').val();
 		var season = $('#seasonSelect').val();
-		popCourses(dbInfo, year, season);
+		listCourses(dbInfo, user, year, season);
 	});
 	
-	$('#courseSelect').change(function() {
-		var year = $('#yearSelect').val();
-		var season = $('#seasonSelect').val();
-		var course = $('#courseSelect').val();
-		popSections(dbInfo, year, season, course);
-	});
-	
-	$('#sectionSelect').change(function() {
-		var sectionID = $('#sectionSelect').val();
-		popAttendance(dbInfo, sectionID);
+	$('#btnReturnToSelect').click(function() {
+		$('#currentSelection').slideUp(500, function() {
+			$('#attnOptionsBox-wrapper').fadeOut();
+			$('#attendanceData').fadeOut();
+			$('#sectionListing').slideDown(500);
+		});
 	});
 	
 	$('#opt-showPresent, #opt-compactTab').change(function() {
 		//reload attendance table since options were modified
-		var sectionID = $('#sectionSelect').val();
-		popAttendance(dbInfo, sectionID);
+		popAttendance(dbInfo, displayedSection);
 	});
 	
 	$('#logout').click(function() {
 		dbInfo = null;
 		instInfo = null;
 		setYears(null); //reset Attendance dropdowns
+
+		$('#sectionListBody').html(''); //clear section list
 		
 		//hide and reset profile
 		$('#profile').css('display', 'none');
@@ -232,49 +233,20 @@ function popSeasons(connInfo, year) {
 	});
 };
 
-function popCourses(connInfo, year, seasonorder) {
-	var urlParams = $.extend({}, connInfo, {year:year, seasonorder:seasonorder});
-	$.ajax('courses', {
-		dataType: 'json',
-		data: urlParams,
-		success: function(result) {
-			var courses = '';
-			for (var i = 0; i < result.courses.length; i++) {
-				courses += '<option value="' + result.courses[i] + '">' + 
-				 result.courses[i] + '</option>';
-			}
-			setCourses(courses);
-		},
-		error: function(result) {
-			showAlert('<p>Error while retrieving courses</p>');
-			console.log(result);
-		}
-	});
-};
+function popAttendance(connInfo, section) {
+	if (typeof(section) !== "object") {
+		section = JSON.parse(section);
+	}
+	displayedSection = section;
+	$('#currentSection').html('<h4>' + displayedSection.sectioncourse + "-" +
+	 displayedSection.sectionnumber + " " + displayedSection.sectiontitle +
+	  ' | ' + $('#seasonSelect option:selected').text() + " " + $('#yearSelect').val() + '</h4>');
 
-function popSections(connInfo, year, seasonorder, coursenumber) {
-	var urlParams = $.extend({}, connInfo, {year:year, seasonorder:seasonorder,
-	 coursenumber:coursenumber});
-	$.ajax('sections', {
-		dataType: 'json',
-		data: urlParams,
-		success: function(result) {
-			var sections = '';
-			for (var i = 0; i < result.sections.length; i++) {
-				sections += '<option value="' + result.sections[i].sectionid +
-				 '">' + result.sections[i].sectionnumber + '</option>';
-			}
-			setSections(sections);
-		},
-		error: function(result) {
-			showAlert('<p>Error while retrieving sections</p>');
-			console.log(result);
-		}
+	$('#sectionListing').slideUp(500, function() {
+		$('#currentSelection').slideDown(500);
 	});
-};
 
-function popAttendance(connInfo, sectionid) {
-	var urlParams = $.extend({}, connInfo, {sectionid:sectionid});
+	var urlParams = $.extend({}, connInfo, {sectionid:section.sectionid});
 	$.ajax('attendance', {
 		dataType: 'html',
 		data: urlParams,
@@ -294,6 +266,66 @@ function popAttendance(connInfo, sectionid) {
 	});
 };
 
+function listCourses(connInfo, user, year, seasonorder) {
+	$('#sectionListBody').html(''); //clear list of sections
+	$('#sectionListingTable').slideDown('slow');
+	var urlParams = $.extend({}, connInfo, {year:year, seasonorder:seasonorder});
+
+	//promises would be helpful here to avoid having 7 levels of indentation
+	$.ajax('courses', {
+		dataType: 'json',
+		data: urlParams,
+		success: function(result) {
+			result.courses.sort();
+			for (var i = 0; i < result.courses.length; i++) {
+				 var urlParams = $.extend({}, connInfo, {year:year, seasonorder:seasonorder,
+					coursenumber:result.courses[i]});
+				$.ajax('sections', {
+					dataType: 'json',
+					data: urlParams,
+					success: function(result) {
+						//sort sections based on section number
+						result.sections.sort(function (a,b) {
+							return a.sectionnumber < b.sectionnumber;
+						});
+
+						//build table row for each section
+						var sections = '';
+						for (var j = 0; j < result.sections.length; j++) {
+							var sectionObjStr = JSON.stringify(result.sections[j]).replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+							sections += '<tr onclick="popAttendance(dbInfo, \'' + sectionObjStr + '\')"';
+							sections += 	' onmouseover="" style="cursor: pointer;">';
+							sections += '<td>' + result.sections[j].sectioncourse + '</td>';
+							sections += '<td>' + result.sections[j].sectionnumber + '</td>';
+							sections += '<td>' + result.sections[j].sectiontitle + '</td>';
+							sections += '<td>' + result.sections[j].sectionschedule + '</td>';
+							sections += '<td>' + result.sections[j].sectionlocation + '</td>';
+							sections += '<td>' + result.sections[j].sectioninstructors + '</td>';
+							sections += '</tr>';
+						}
+
+						//append new section to section list
+						appendSectionList(sections);
+					},
+					error: function(result) {
+						showAlert('<p>Error while retrieving sections</p>');
+						console.log(result);
+					}
+				});
+			}
+		},
+		error: function(result) {
+			showAlert('<p>Error while retrieving courses</p>');
+			console.log(result);
+		}
+	});
+};
+
+function appendSectionList(htmlText) {
+	var currList = $('#sectionListBody').html();
+	$('#sectionListBody').html(currList + htmlText);
+};
+
 function setYears(htmlText) {
 	var content = '<option value="" disabled="true" selected="true">' +
 	 'Choose year</option>' + htmlText;
@@ -301,7 +333,7 @@ function setYears(htmlText) {
 	$('#yearSelect').prop('disabled', htmlText == null);
 	$('#yearSelect').material_select(); //reload dropdown
 	
-	setSeasons(null); //reset dependent fields
+	setSeasons(null); //reset dependent field
 };
 
 function setSeasons(htmlText) {
@@ -310,28 +342,8 @@ function setSeasons(htmlText) {
 	$('#seasonSelect').html(content);
 	$('#seasonSelect').prop('disabled', htmlText == null);
 	$('#seasonSelect').material_select(); //reload dropdown
-	
-	setCourses(null); //reset dependent fields
-};
 
-function setCourses(htmlText) {
-	var content = '<option value="" disabled="true" selected="true">' +
-	 'Choose course</option>' + htmlText;
-	$('#courseSelect').html(content);
-	$('#courseSelect').prop('disabled', htmlText == null);
-	$('#courseSelect').material_select(); //reload dropdown
-	
-	setSections(null); //reset dependent fields
-};
-
-function setSections(htmlText) {
-	var content = '<option value="" disabled="true" selected="true">' +
-	 'Choose section</option>' + htmlText;
-	$('#sectionSelect').html(content);
-	$('#sectionSelect').prop('disabled', htmlText == null);
-	$('#sectionSelect').material_select(); //reload dropdown
-	
-	setAttendance(null);
+	$('#sectionListBody').html(''); //clear section list
 };
 
 function setAttendance(htmlText) {
@@ -340,7 +352,7 @@ function setAttendance(htmlText) {
 	
 	if (htmlText == null) {
 		$('#attendanceData').html('');
-		$('#attnOptionsBox').css('display', 'none');
+		$('#attnOptionsBox-wrapper').fadeOut();
 	}
 	else {
 		if (htmlText.substring(0, 7) !== '<table>') {
@@ -365,7 +377,8 @@ function setAttendance(htmlText) {
 				htmlText = '<table class="striped">' + htmlText.substring(7);
 			}
 		}
-		$('#attnOptionsBox').css('display', 'block');
 		$('#attendanceData').html(htmlText);
+		$('#attnOptionsBox-wrapper').fadeIn();
+		$('#attendanceData').fadeIn();
 	}
 };

--- a/src/webapp/client/js/index.js
+++ b/src/webapp/client/js/index.js
@@ -56,6 +56,18 @@ $(document).ready(function() {
 			$('#optionsArrow').html('keyboard_arrow_down');
 		}
 	});
+
+	$('#email').keyup(function(event) {
+		if (event.keyCode == 13) {
+			$('#btnLogin').click();
+		}
+	});
+
+	$('#passwordBox').keyup(function(event) {
+		if (event.keyCode == 13) {
+			$('#btnLogin').click();
+		}
+	});
 	
 	$('#btnLogin').click(function() {
 		dbInfo = getDBFields();

--- a/src/webapp/gradebookServer.js
+++ b/src/webapp/gradebookServer.js
@@ -293,7 +293,10 @@ app.get('/sections', function(request, response) {
    var seasonOrder = request.query.seasonorder;
    var courseNumber = request.query.coursenumber;
 
-   var queryText = 'SELECT SectionID, SectionNumber FROM getInstructorSections($1, $2, $3, $4);';
+   var queryText = 'SELECT SectionID, Course, GIS.SectionNumber, Title,' +
+                   ' Schedule, Location, Instructors FROM' +
+                   ' getInstructorSections($1, $2, $3, $4) GIS,' +
+                   ' getSection(GIS.sectionID);';
    var queryParams = [instructorID, year, seasonOrder, courseNumber];
 
    executeQuery(response, config, queryText, queryParams, function(result) {
@@ -302,7 +305,12 @@ app.get('/sections', function(request, response) {
          sections.push(
             {
                "sectionid": result.rows[row].sectionid,
-               "sectionnumber": result.rows[row].sectionnumber
+               "sectioncourse": result.rows[row].course,
+               "sectionnumber": result.rows[row].sectionnumber,
+               "sectiontitle": result.rows[row].title,
+               "sectionschedule" : result.rows[row].schedule,
+               "sectionlocation" : result.rows[row].location,
+               "sectioninstructors" : result.rows[row].instructors
             }
          );
       }

--- a/src/webapp/gradebookServer.js
+++ b/src/webapp/gradebookServer.js
@@ -224,8 +224,8 @@ app.get('/seasons', function(request, response) {
       queryText = 'SELECT SeasonOrder, SeasonName FROM getSeasonsAsStudent();';
    }
    else {
-      queryText = 'SELECT S."Order", S.Name FROM term T JOIN season S ON ' +
-                  'T.season = S."Order" WHERE T.Year = $1;';
+      queryText = 'SELECT S."Order" AS SeasonOrder, S.Name AS SeasonName FROM' + 
+                  ' term T JOIN season S ON T.season = S."Order" WHERE T.Year = $1;';
       queryParams = [year];
    }
 


### PR DESCRIPTION
This PR introduces one large change and several small changes to the Gradebook UI (and backend):

Large change:

- Rather than having four drop-downs to select a section to view (attendance) data for, the user is now only required to choose year and season, at which point they will be presented a list of sections that they are teaching or enrolled in for the chosen term. They can then click on one of the sections to load data for it. A button is presented to return to the list of courses.

Small changes:

- The title of the currently chosen section is now displayed when attendance data is shown on screen. This involved updating the return values of the middleware `/sections` endpoint (additional attributes were added to the JSON object, previous attributes maintained their original names for backwards compatibility).
- It is now possible to initiate a login by pressing the enter key while in the email (future school issued ID) or password fields. Previously, it was only possible by clicking on the login button.
- getSection DB functions were updated to also return the section's title in the returned table.
- Fix query in `/seasons` endpoint for unknown user roles (returns all institutionally recognized seasons).
- Added cool animations when loading attendance data.