### PR TITLE
Fix execution of the truncate command in roster import

### DIFF
--- a/src/webapp/gradebookServer.js
+++ b/src/webapp/gradebookServer.js
@@ -639,7 +639,9 @@ app.post('/importSectionRoster', function(request, response) {
                queryText = 'TRUNCATE TABLE RosterStaging;';
                queryParams = [];
 
-               response.status(202).send('Procedure finished');
+               executeQuery(response, config, queryText, queryParams, function(result) {
+                  response.status(202).send('Procedure finished');
+               });
             });
          });
          fstream.pipe(stream);


### PR DESCRIPTION
Actually executes the truncate command and sends a response at the correct time. This change was not included in PR #55 when it should have been.

Due to it's simplicity and in the interest of time, the change will likely be merged even with only one approving review.